### PR TITLE
Fixing $in_commment, line 70

### DIFF
--- a/gen_doc.php
+++ b/gen_doc.php
@@ -65,9 +65,9 @@ function gen_doc($file, $output_dir, $template=null){
 	$lines = file($file);
 	foreach($lines as $line){
 		if($line[0] == '`'){
-			$in_commment = $in_commment? false:true;
+			$in_comment = $in_comment? false:true;
 		}
-		if($line[0] == '#' && $line[1] != '#' && !$in_commment){
+		if($line[0] == '#' && $line[1] != '#' && !$in_comment){
 			$line = trim($line);
 			$line = trim($line, '#');
 			$line = trim($line);


### PR DESCRIPTION
The make command outputs: `PHP Notice:  Undefined variable: in_commment in ... line 70` due to a simple error syntax: `$in_comment` is declared at line 64 correctly, then from line 68 to 70 is written with three m: `in_commment`.
