### PR TITLE
 增加 go 的 ssdb 客户端

### DIFF
--- a/src/clients.md
+++ b/src/clients.md
@@ -88,6 +88,16 @@ If you want your client be listed here, please fork the [ssdb-docs repository](h
 			hissdb in lessgo, supports connection pool.
 		</td>
 	</tr>
+	<tr>
+		<td width="15%">gossdb</td>
+		<td width="15%">seefan</td>
+		<td width="20%">
+			<a href="https://github.com/seefan/gossdb">Repository</a>
+		</td>
+		<td>
+			From the official client derived from the client, supports the connection pool and set|get, habits and most client consistent.
+		</td>
+	</tr>
 </table>
 
 ### <a href="#java" name="java">Java</a>

--- a/src/zh_cn/clients.md
+++ b/src/zh_cn/clients.md
@@ -88,6 +88,16 @@ SSDB 源码仓库中, 内置了许多语言的客户端, 这些便是所谓的__
 			在 lessgo 项目中的 hissdb, 支持连接池.
 		</td>
 	</tr>
+	<tr>
+		<td width="15%">gossdb</td>
+		<td width="15%">seefan</td>
+		<td width="20%">
+			<a href="https://github.com/seefan/gossdb">Repository</a>
+		</td>
+		<td>
+			从官方客户端派生出来的客户端，支持连接池，使用习惯与大多数客户端保持一致。
+		</td>
+	</tr>
 </table>
 
 ### <a href="#java" name="java">Java</a>


### PR DESCRIPTION
从官方客户端派生出来的客户端，支持连接池，支持 set 和 get 方法，使用习惯与大多数客户端保持一致。