### PR TITLE
add parameter "name" to both hscan and hrscan

### DIFF
--- a/src/commands/hrscan.md
+++ b/src/commands/hrscan.md
@@ -1,3 +1,3 @@
-# hrscan key_start key_end limit
+# hrscan name key_start key_end limit
 
 Like [hscan](./hscan.html), but in reverse order.

--- a/src/commands/hscan.md
+++ b/src/commands/hscan.md
@@ -1,4 +1,4 @@
-# hscan key_start key_end limit
+# hscan name key_start key_end limit
 
 List key-value pairs of a hashmap with keys in range `(key_start, key_end]`.
 

--- a/src/commands/index.md
+++ b/src/commands/index.md
@@ -439,7 +439,7 @@
 		<span class="command">
 			hscan
 			<span class="args">
-				key_start key_end limit
+				name key_start key_end limit
 			</span>
 		</span>
 		<span class="summary">List key-value pairs of a hashmap with keys in range (key_start, key_end].</span>
@@ -450,7 +450,7 @@
 		<span class="command">
 			hrscan
 			<span class="args">
-				key_start key_end limit
+				name key_start key_end limit
 			</span>
 		</span>
 		<span class="summary">List key-value pairs with keys in range (key_start, key_end], in reverse order.</span>

--- a/src/zh_cn/commands/hrscan.md
+++ b/src/zh_cn/commands/hrscan.md
@@ -1,3 +1,3 @@
-# hrscan key_start key_end limit
+# hrscan name key_start key_end limit
 
 类似 [hscan](./hlist.html), 逆序.

--- a/src/zh_cn/commands/hscan.md
+++ b/src/zh_cn/commands/hscan.md
@@ -1,4 +1,4 @@
-# hscan key_start key_end limit
+# hscan name key_start key_end limit
 
 列出 hashmap 中处于区间 (key_start, key_end] 的 key-value 列表.
 

--- a/src/zh_cn/commands/index.md
+++ b/src/zh_cn/commands/index.md
@@ -439,7 +439,7 @@
 		<span class="command">
 			hscan
 			<span class="args">
-				key_start key_end limit
+				name key_start key_end limit
 			</span>
 		</span>
 		<span class="summary">列出 hashmap 中处于区间 (key_start, key_end] 的 key-value 列表.</span>
@@ -450,7 +450,7 @@
 		<span class="command">
 			hrscan
 			<span class="args">
-				key_start key_end limit
+				name key_start key_end limit
 			</span>
 		</span>
 		<span class="summary">像 hscan, 逆序.</span>


### PR DESCRIPTION
刚开始看 ssdb 的文档，发现 hscan 和 hrscan 的参数列表里少了 name 这个参数，实际中是有的