### PR TITLE
Add Init script setup for ubuntu

### DIFF
--- a/src/install.md
+++ b/src/install.md
@@ -92,5 +92,6 @@ sudo chkconfig ssdb on
 __Ubuntu__
 
 <pre>
-TODO:
+sudo chmod a+x /etc/init.d/ssdb
+sudo update-rc.d ssdb defaults
 </pre>


### PR DESCRIPTION
I added missing setup in Ubuntu for the init script

```
sudo chmod a+x /etc/init.d/ssdb
sudo update-rc.d ssdb defaults
```